### PR TITLE
Fix JSON lib version check

### DIFF
--- a/src/ruby/json_polyfill.rb
+++ b/src/ruby/json_polyfill.rb
@@ -12,7 +12,7 @@ class Bridge
       # As a workaround, we use `load`.
       load 'json.rb' unless defined?(::JSON)
       # No support for option :quirks_mode ? Fallback to JSON implementation in this library.
-      raise(RuntimeError) unless ::JSON::VERSION_MAJOR >= 1 && ::JSON::VERSION_MINOR >= 6
+      raise(RuntimeError) unless ::JSON::VERSION_MAJOR >= 2 || (::JSON::VERSION_MAJOR >= 1 && ::JSON::VERSION_MINOR >= 6)
 
       module JSON
         def self.generate(object)


### PR DESCRIPTION
There is a bug with this line when the major version is higher than 1:
`raise(RuntimeError) unless ::JSON::VERSION_MAJOR >= 1 && ::JSON::VERSION_MINOR >= 6`

For example, the JSON lib in SketchUp 2020 is v2.1.0, but this line will raise an error because it's lower than 2.6.0.

Another alternative could be to use `Gem::Version` which ships with SU.